### PR TITLE
fix: Add -I/usr/local/opt/openblas/include for darwin in rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
 ]}.
 
 {port_env, [
-    {"darwin", "CFLAGS", "$CFLAGS -I/usr/local/include -I/opt/homebrew/include -I/opt/homebrew/opt/openblas/include -fPIC -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes"}, 
+    {"darwin", "CFLAGS", "$CFLAGS -I/usr/local/opt/openblas/include -I/usr/local/include -I/opt/homebrew/include -I/opt/homebrew/opt/openblas/include -fPIC -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes"}, 
     {"darwin", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -finline-functions -Wall"},
     {"darwin", "LDFLAGS", "$LDFLAGS -L/opt/homebrew/opt/openblas/lib -flat_namespace -undefined suppress  -lm"},
 


### PR DESCRIPTION
In an old homebrew, `/usr/local/opt/openblas/include` is used for OpenBLAS headers. Adding this will do no harm on a newer homebrew installation.